### PR TITLE
input_files/fastas -> esmfold in runner_tests.py for ESMFold

### DIFF
--- a/tests/runner_tests.py
+++ b/tests/runner_tests.py
@@ -87,7 +87,7 @@ def main(args):
     runner_dict = {
         "ESMFold": {
             "runner": ESMFold() if protflow.config.ESMFOLD_PYTHON_PATH else None,
-            "poses_options": {"poses": "input_files/fastas/", "glob_suffix": "*.fasta"},
+            "poses_options": {"poses": "input_files/esmfold/", "glob_suffix": "*.fasta"},
             "runner_options": {"jobstarter": jobstarter or js_dict['slurm_gpu_jobstarter']},
             "config": [protflow.config.ESMFOLD_PYTHON_PATH]
         },


### PR DESCRIPTION
"poses" in the ESMFold test runner should point to input_files/esmfold instead of input_files/fastas. Otherwise the ESMFold tests always fail because of this error:

Merging DataFrames failed. This means there was no overlap found between poses.df['poses_description'] and results[new_df_col]