### PR TITLE
fixed Bug where fasta seqs were passed on as SeqRecords instead of st…

### DIFF
--- a/docs/source/tools/index.rst
+++ b/docs/source/tools/index.rst
@@ -1,13 +1,10 @@
 Tools
 =====
 
-ProtFlow Tools package
-----------------------
-
 This section provides detailed guides on how to use tools implemented as Runners in ProtFlow.
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     boltz
  

--- a/protflow/tools/boltz.py
+++ b/protflow/tools/boltz.py
@@ -610,7 +610,7 @@ def convert_poses_to_boltz_yaml(poses: Poses, prefix: str, msa: str = None, over
     # get sequence from poses, this differs depending on which type of pose we have (.fasta or .pdb/.cif).
     if all(pose.endswith((".fa", ".fas", ".fasta")) for pose in poses.poses_list()):
         # load raw sequences
-        sequences = [load_sequence_from_fasta(pose, return_multiple_entries=False) for pose in poses.poses_list()]
+        sequences = [str(load_sequence_from_fasta(pose, return_multiple_entries=False).seq) for pose in poses.poses_list()]
 
         # assign chain IDs for sequences (start with [A -> Z], then [AA -> ZZ]):
         sequence_dict_list = [{idx_to_char(i): chain_seq for i, chain_seq in enumerate(seq.split(_determine_split_char(seq)))} for seq in sequences]

--- a/protflow/utils/biopython_tools.py
+++ b/protflow/utils/biopython_tools.py
@@ -75,6 +75,7 @@ from Bio import SeqIO
 from Bio.SeqUtils.ProtParam import ProteinAnalysis
 from Bio.SeqUtils import seq1, seq3
 from Bio.PDB import Polypeptide, MMCIFParser
+from Bio.SeqRecord import SeqRecord
 import Bio.PDB.Model
 import Bio.PDB.Structure
 
@@ -724,7 +725,7 @@ def renumber_pose_by_residue_mapping(pose: Bio.PDB.Structure.Structure, residue_
     return out_pose
 
 ######################## Bio.Seq functions ##########################################
-def load_sequence_from_fasta(fasta:str, return_multiple_entries:bool=True):
+def load_sequence_from_fasta(fasta: str, return_multiple_entries: bool = True) -> SeqRecord:
     """
     Load a sequence from a FASTA file.
 


### PR DESCRIPTION
…rings, causing crash when trying sey.split()