### PR TITLE
fix de novo run bugs in RFdiffusion3 

### DIFF
--- a/examples/rfdiffusion3.ipynb
+++ b/examples/rfdiffusion3.ipynb
@@ -39,7 +39,7 @@
     "import protflow\n",
     "from protflow.jobstarters import SbatchArrayJobstarter\n",
     "from protflow.poses import Poses\n",
-    "from protflow.tools.rfdiffusion3 import RFdiffusion3\n",
+    "from protflow.tools.rfdiffusion3 import RFdiffusion3, RFD3Params\n",
     "from protflow.residues import residue_selection\n",
     "\n",
     "# logging\n",
@@ -115,19 +115,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# length='100' means exactly 100 residues\n",
+    "# RFD3Params holds the per-pose input specification for RFD3.\n",
+    "# For de novo (empty poses), it creates a single \"denovo\" entry automatically.\n",
+    "# set_input_specs(length='100') sets the length to exactly 100 residues for that entry.\n",
+    "params = RFD3Params(poses=poses_denovo)\n",
+    "params.set_input_specs(length='100')\n",
+    "\n",
     "# 1 batch x diffusion_batch_size=8  ->  8 output structures\n",
     "# overwrite=True ensures a clean run even if outputs already exist\n",
     "poses_denovo = rfdiffusion3.run(\n",
     "    poses=poses_denovo,\n",
     "    prefix='rfdiffusion3',\n",
-    "    length='100',\n",
+    "    params=params,\n",
     "    n_batches=1,\n",
     "    diffusion_batch_size=8,\n",
     "    overwrite=True,\n",
     ")\n",
     "\n",
-    "print(f'De novo run complete: {len(poses_denovo.df.index)} output poses')"
+    "print(f'De novo run complete: {len(poses_denovo.df.index)} output poses')\n"
    ]
   },
   {

--- a/protflow/tools/rfdiffusion3.py
+++ b/protflow/tools/rfdiffusion3.py
@@ -1032,7 +1032,7 @@ class RFdiffusion3(Runner):
 
 
         # check if input_specification fits to input poses
-        if poses and not all(name in params for name in poses.df["poses_description"]) or not len(poses) == len(params):
+        if poses and (not all(name in params for name in poses.df["poses_description"]) or not len(poses) == len(params)):
             raise ValueError("Input <poses> do not match <input_specification>")
         
         ckpt_path = identify_checkpoint(ckpt_path)
@@ -1084,6 +1084,8 @@ class RFdiffusion3(Runner):
             if not poses:
                 poses.df = scores.copy()
                 poses.df["input_poses"] = None
+                poses.df["poses"] = poses.df["location"].apply(os.path.abspath)
+                poses.df["poses_description"] = poses.df["description"]
                 logging.info("Populated poses.df from scorefile.")
             else:
                 poses = RunnerOutput(poses=poses, results=scores, prefix=prefix, index_layers=index_layers).return_poses()
@@ -1148,6 +1150,8 @@ class RFdiffusion3(Runner):
         if not poses:
             poses.df = scores.copy()
             poses.df["input_poses"] = None
+            poses.df["poses"] = poses.df["location"].apply(os.path.abspath)
+            poses.df["poses_description"] = poses.df["description"]
             logging.info(
                 f"Populated poses.df directly from scores {len(poses.df.index)} rows).")
         else:


### PR DESCRIPTION
fix de novo run bugs in RFdiffusion3  params-based API and update tuto…rial

Two bugs fixed in RFdiffusion3.run() for de novo (empty poses) mode:

esp. check second one for correct fix.

1. Operator precedence in input validation: the `or not len(poses) == len(params)` clause was evaluated unconditionally. For empty poses, `not (0 == 1)` always returned True and raised ValueError even for valid empty de novo input. Fixed by wrapping both conditions in parentheses so the length check is also guarded by `if poses`.

2. Missing poses,poses_description columns after de novo score assignment: when RFD3 runs in de novo mode, scores are assigned directly to poses.df instead of going through RunnerOutput. Both the fresh run path and the scorefile-reuse path were missing the assignment, causing downstream runners (e.g. reindex_poses) to raise KeyError: "poses_description", "poses". Fixed by explicitly setting poses and poses_description from location and description after the assignment.

    - Make sure this is the proper way to fix this. Might be wrong!!

Tutorial notebook updated to use the params-based API for de novo design: RFD3Params is constructed from the empty poses object and length is passed via set_input_specs() rather than as a direct argument to run(), since run() no longer accepts length as an argument. The tutorial text is updated too.