### PR TITLE
Changed Documentation,  score storing minor bugfixes.

### DIFF
--- a/docs/source/tools/sigmadock.rst
+++ b/docs/source/tools/sigmadock.rst
@@ -93,12 +93,30 @@ pose-prediction accuracy.
         poses=my_poses,
         prefix="redock",
         ligand_name="LIG",   # residue name of the ligand in the input complex
-        num_seeds=1,        # number of independent samples per pose (see SigmaDock docs for details)
+        num_seeds=1,        # independent samples per pose; all run on ONE GPU — keep moderate (see note below)
         overwrite=False,
     )
 
     # scores are available as prefixed columns
     display(my_poses.df[["redock_affinity", "redock_rmsd", "redock_pb_pass_rate"]])
+
+.. note::
+
+    **Choosing ``num_seeds`` and scaling up.**
+    ``num_seeds`` sets how many independent docking samples are drawn per pose.
+    All draws for a pose run in a **single process on one GPU** (the runner
+    fixes ``hardware.devices=1``), so the effective batch is
+    ``batch_size × num_seeds`` — a large value can exhaust GPU memory (OOM).
+    ``num_seeds`` does **not** parallelise across GPUs; keep it moderate, sized
+    to fit a single GPU.
+
+    To dock **many poses** in parallel, scale out with the jobstarter rather
+    than ``num_seeds``.  ``SbatchArrayJobstarter(max_cores=N, gpus=1)`` runs one
+    pose per GPU and lets at most ``N`` run concurrently, so raising
+    ``max_cores`` (up to your available GPUs) is the lever for throughput.  For
+    large pose diversity, SigmaDock's authors recommend several runs / a SLURM
+    job array over a very large ``num_seeds``, which also gives cleaner
+    reproducibility.
 
 Crossdocking
 ------------

--- a/examples/sigmadock.ipynb
+++ b/examples/sigmadock.ipynb
@@ -69,26 +69,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "cb56e0a7",
+   "source": "> **Note — `num_seeds` and scaling.** `num_seeds` sets how many independent docking samples are drawn per pose. **All draws for a pose run in a single process on one GPU** (the runner fixes `hardware.devices=1`), so the effective batch is `batch_size × num_seeds` and a large value can exhaust GPU memory (OOM). `num_seeds` does **not** parallelise across GPUs — keep it moderate, sized to fit a single GPU.\n>\n> To dock **many poses** at once, scale out with the jobstarter instead of `num_seeds`: `SbatchArrayJobstarter(max_cores=N, gpus=1)` runs one pose per GPU and lets at most `N` run concurrently, so raising `max_cores` (up to the number of GPUs you have) is the lever for throughput. For large pose diversity, SigmaDock's authors recommend several runs / a SLURM job array over a very large `num_seeds` (also cleaner for reproducibility).",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "mode1-run",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "poses = Poses(poses=[COMPLEX_CIF], work_dir=WORK_DIR)\n",
-    "\n",
-    "poses = runner.run(\n",
-    "    poses=poses,\n",
-    "    prefix=\"redock_from_complex\",\n",
-    "    num_seeds=3, # use num_seeds for multiple independent samples per pose; each sample gets a zero-padded index suffix in the output files and scores\n",
-    "    ligand_name=LIGAND_NAME,\n",
-    "    overwrite=True,\n",
-    ")\n",
-    "\n",
-    "for col in poses.df.columns:\n",
-    "    if col.startswith(\"redock_from_complex\"):\n",
-    "        print(f\"{col}: {poses.df[col]}\")"
-   ]
+   "source": "poses = Poses(poses=[COMPLEX_CIF], work_dir=WORK_DIR)\n\nposes = runner.run(\n    poses=poses,\n    prefix=\"redock_from_complex\",\n    num_seeds=3, # independent samples per pose (zero-padded index suffix in outputs/scores); all run on ONE GPU — keep moderate to avoid OOM. See the note above on scaling.\n    ligand_name=LIGAND_NAME,\n    overwrite=True,\n)\n\nfor col in poses.df.columns:\n    if col.startswith(\"redock_from_complex\"):\n        print(f\"{col}: {poses.df[col]}\")"
   },
   {
    "cell_type": "markdown",

--- a/protflow/tools/runners_auxiliary_scripts/sigmadock_collect_scores.py
+++ b/protflow/tools/runners_auxiliary_scripts/sigmadock_collect_scores.py
@@ -40,6 +40,9 @@ description : str
     Stem of the pose directory name (matches ``poses.df["description"]``).
 location : str
     Absolute path to the written complex PDB.
+seed : int
+    Effective per-draw random seed used by SigmaDock for this pose
+    (read from the prediction record; reflects per-pose ``pose_options``).
 affinity : float
     Predicted binding affinity from ``rescoring.pt`` (lower is better).
 intramolecular_energy : float
@@ -162,6 +165,7 @@ def collect(work_dir: str, include_scores: set[str] | None = None) -> list[dict]
                 row = {
                     "description": description,
                     "location":    str(out_complex.resolve()),
+                    "seed":        s.get("seed"),  # effective per-draw seed from SigmaDock's record
                 }
 
                 if rescore is not None:

--- a/protflow/tools/sigmadock.py
+++ b/protflow/tools/sigmadock.py
@@ -182,6 +182,18 @@ class SigmaDock(Runner):
             Number of independent stochastic draws per pose (``num_seeds``
             in SigmaDock's Hydra config).  Each seed produces one docked
             pose, written as ``{description}_{i:04d}.pdb``.
+
+            **Caution — this does not parallelise across GPUs.** All draws for
+            a pose run in a single process on one GPU (the runner fixes
+            ``hardware.devices=1``), so the effective batch becomes
+            ``batch_size × num_seeds`` and a large value can exhaust GPU memory
+            (OOM).  Keep ``num_seeds`` moderate sized to fit one GPU's
+            memory.  To dock many poses at once, scale out with the jobstarter
+            (e.g. ``SbatchArrayJobstarter(max_cores=N, gpus=1)``), which runs
+            one process per pose across up to ``N`` GPUs.  For large pose
+            diversity prefer several runs / a SLURM job array over a very large
+            ``num_seeds`` (SigmaDock's authors recommend this for cleaner
+            reproducibility too).
         seed:
             Master random seed (``seed`` in SigmaDock's Hydra config).
             SigmaDock derives ``num_seeds`` per-draw seeds from this value,

--- a/protflow/tools/sigmadock.py
+++ b/protflow/tools/sigmadock.py
@@ -198,7 +198,10 @@ class SigmaDock(Runner):
             Master random seed (``seed`` in SigmaDock's Hydra config).
             SigmaDock derives ``num_seeds`` per-draw seeds from this value,
             so the same ``seed`` + ``num_seeds`` combination always reproduces
-            the same set of poses.  Stored as ``{prefix}_master_seed``.
+            the same set of poses.  The effective per-draw seed of each result
+            is recorded in the ``{prefix}_seed`` column, read back from
+            SigmaDock's output records (so per-pose overrides via
+            ``pose_options`` are reflected correctly).
         query_ligands:
             Absolute SDF paths for crossdocking from complex.  One list is
             shared across all poses.
@@ -292,7 +295,6 @@ class SigmaDock(Runner):
 
         if len(scores.index) == 0:
             raise RuntimeError(f"{self}: collect_scores returned no rows. Check runner output logs and runner output directory ({work_dir})")
-        scores["master_seed"] = seed
         if len(scores.index) < len(poses) * num_seeds:
             logging.warning("%s: expected %d rows (%d poses × %d seeds), got %d — some runs may have crashed.", self, len(poses) * num_seeds, len(poses), num_seeds, len(scores.index))
 

--- a/protflow/utils/biopython_tools.py
+++ b/protflow/utils/biopython_tools.py
@@ -1238,6 +1238,14 @@ def split_complex(path: str, work_dir: str, ligand_name: str) -> None:
 
     structure = biopython_load_structure(path, handle=stem)
 
+    # fail fast if the requested ligand is absent, instead of silently writing an empty SDF
+    if not any(residue.resname == ligand_name for residue in structure.get_residues()):
+        hetatms = sorted({residue.resname for residue in structure.get_residues() if residue.id[0] != " "})
+        raise ValueError(
+            f"No residue named '{ligand_name}' found in {path}. "
+            f"HETATM residues present: {hetatms or 'none'}. Check the ligand_name argument."
+        )
+
     class _ProteinSelect(Bio.PDB.Select): # inherit from Bio.PDB.Select to write only ATOM records
         def accept_residue(self, residue):
             return residue.id[0] == " "


### PR DESCRIPTION
Minor changes, manly documentation on seed usage.

- Implemented correct seed storage.
- Updated docs to recommend arrays over num_seeds: num_seeds>1 packs multiple draws into one job (weaker reproducibility); use num_seeds=1 with multiple seeds for independent, reproducible samples (see README and slurm/sample.sh).
- Biopython tool now properly crashes without correct ligand naming, previously run into recursion errors with no meaningful error output
- Adapted example jupyter notebook to mention num seeds and GPU OOM possibility properly.